### PR TITLE
Fix lint and type errors for CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,8 @@ strict = true
 [[tool.mypy.overrides]]
 module = "grpc.*"
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "google.protobuf.*"
+ignore_missing_imports = true
+follow_imports = "skip"

--- a/src/api/auth/controllers.py
+++ b/src/api/auth/controllers.py
@@ -29,7 +29,7 @@ router = APIRouter(prefix="/auth", tags=["auth"], route_class=DishkaRoute)
 @router.post(
     "/register", status_code=201, response_model=RegisterResponse, responses={**CONFLICT_ERRORS}
 )
-async def register(body: RegisterRequest, stub: FromDishka[AuthServiceStub]):
+async def register(body: RegisterRequest, stub: FromDishka[AuthServiceStub]) -> RegisterResponse:
     response = await stub.Register(
         auth_pb.RegisterRequest(username=body.username, email=body.email, password=body.password)
     )
@@ -44,7 +44,7 @@ async def register(body: RegisterRequest, stub: FromDishka[AuthServiceStub]):
 async def login(
     form_data: Annotated[OAuth2PasswordRequestForm, Depends(OAuth2PasswordRequestForm)],
     stub: FromDishka[AuthServiceStub],
-):
+) -> TokenResponse:
     response = await stub.Login(
         auth_pb.LoginRequest(email=form_data.username, password=form_data.password)
     )
@@ -52,7 +52,7 @@ async def login(
 
 
 @router.post("/refresh", response_model=TokenResponse, responses={**AUTH_ERRORS})
-async def refresh(body: RefreshRequest, stub: FromDishka[AuthServiceStub]):
+async def refresh(body: RefreshRequest, stub: FromDishka[AuthServiceStub]) -> TokenResponse:
     response = await stub.RefreshTokens(
         auth_pb.RefreshTokensRequest(refresh_token=body.refresh_token)
     )
@@ -60,7 +60,7 @@ async def refresh(body: RefreshRequest, stub: FromDishka[AuthServiceStub]):
 
 
 @router.post("/logout", response_model=SuccessResponse)
-async def logout(body: LogoutRequest, stub: FromDishka[AuthServiceStub]):
+async def logout(body: LogoutRequest, stub: FromDishka[AuthServiceStub]) -> SuccessResponse:
     response = await stub.Logout(auth_pb.LogoutRequest(refresh_token=body.refresh_token))
     return SuccessResponse(success=response.success)
 
@@ -69,7 +69,7 @@ async def logout(body: LogoutRequest, stub: FromDishka[AuthServiceStub]):
 async def get_me(
     stub: FromDishka[AuthServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> UserResponse:
     response = await stub.GetMe(auth_pb.GetMeRequest(user_id=current_user.user_id))
     return UserResponse(
         user_id=response.user_id,
@@ -80,12 +80,12 @@ async def get_me(
 
 
 @router.post("/send-otp", response_model=SuccessResponse)
-async def send_otp(body: SendOtpRequest, stub: FromDishka[AuthServiceStub]):
+async def send_otp(body: SendOtpRequest, stub: FromDishka[AuthServiceStub]) -> SuccessResponse:
     response = await stub.SendOtp(auth_pb.SendOtpRequest(email=body.email))
     return SuccessResponse(success=response.success)
 
 
 @router.post("/verify-otp", response_model=SuccessResponse)
-async def verify_otp(body: VerifyOtpRequest, stub: FromDishka[AuthServiceStub]):
+async def verify_otp(body: VerifyOtpRequest, stub: FromDishka[AuthServiceStub]) -> SuccessResponse:
     response = await stub.VerifyOtp(auth_pb.VerifyOtpRequest(email=body.email, code=body.code))
     return SuccessResponse(success=response.success)

--- a/src/api/devices/actuators.py
+++ b/src/api/devices/actuators.py
@@ -43,7 +43,7 @@ async def create_actuator(
     body: CreateActuatorRequest,
     stub: FromDishka[DevicesServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> CreateActuatorResponse:
     response = await stub.CreateActuator(
         devices_pb.CreateActuatorRequest(
             user_id=current_user.user_id,
@@ -51,7 +51,7 @@ async def create_actuator(
             device_id=str(device_id),
             key=body.key,
             name=body.name,
-            value_type=VALUE_TYPE_TO_PROTO[body.value_type],
+            value_type=VALUE_TYPE_TO_PROTO[body.value_type],  # type: ignore[arg-type]
             unit_label=body.unit_label,
             precision=body.precision,
             min_value=body.min_value if body.min_value is not None else 0,
@@ -73,7 +73,7 @@ async def list_actuators(
     device_id: UUID,
     stub: FromDishka[DevicesServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> ActuatorListResponse:
     response = await stub.ListActuators(
         devices_pb.ListActuatorsRequest(
             user_id=current_user.user_id, place_id=str(place_id), device_id=str(device_id)
@@ -96,7 +96,7 @@ async def update_actuator(
     body: UpdateActuatorRequest,
     stub: FromDishka[DevicesServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> UpdateActuatorResponse:
     response = await stub.UpdateActuator(
         devices_pb.UpdateActuatorRequest(
             user_id=current_user.user_id,
@@ -126,7 +126,7 @@ async def delete_actuator(
     actuator_id: UUID,
     stub: FromDishka[DevicesServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> SuccessResponse:
     response = await stub.DeleteActuator(
         devices_pb.DeleteActuatorRequest(
             user_id=current_user.user_id,

--- a/src/api/devices/commands.py
+++ b/src/api/devices/commands.py
@@ -26,7 +26,7 @@ async def send_command(
     body: SendCommandRequest,
     stub: FromDishka[DevicesServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> SuccessResponse:
     response = await stub.SendCommand(
         devices_pb.SendCommandRequest(
             user_id=current_user.user_id,

--- a/src/api/devices/devices.py
+++ b/src/api/devices/devices.py
@@ -9,7 +9,7 @@ from placebrain_contracts import devices_pb2 as devices_pb
 from placebrain_contracts.collector_pb2_grpc import CollectorServiceStub
 from placebrain_contracts.devices_pb2_grpc import DevicesServiceStub
 
-from src.core.enums import STATUS_FROM_PROTO
+from src.core.enums import STATUS_FROM_PROTO, DeviceStatus
 from src.dependencies.auth import AuthenticatedUser
 from src.schemas.base import (
     AUTH_ERRORS,
@@ -49,7 +49,7 @@ async def create_device(
     body: CreateDeviceRequest,
     stub: FromDishka[DevicesServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> CreateDeviceResponse:
     response = await stub.CreateDevice(
         devices_pb.CreateDeviceRequest(
             user_id=current_user.user_id, place_id=str(place_id), name=body.name
@@ -68,7 +68,7 @@ async def list_devices(
     stub: FromDishka[DevicesServiceStub],
     current_user: AuthenticatedUser,
     pagination: PaginationParams,
-):
+) -> PaginatedResponse[DeviceSummaryResponse]:
     response = await stub.ListDevices(
         devices_pb.ListDevicesRequest(
             user_id=current_user.user_id,
@@ -97,7 +97,7 @@ async def get_device(
     device_id: UUID,
     stub: FromDishka[DevicesServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> DeviceDetailResponse:
     response = await stub.GetDevice(
         devices_pb.GetDeviceRequest(
             user_id=current_user.user_id, place_id=str(place_id), device_id=str(device_id)
@@ -108,7 +108,7 @@ async def get_device(
         device_id=d.device_id,
         place_id=d.place_id,
         name=d.name,
-        status=STATUS_FROM_PROTO.get(d.status, "offline"),
+        status=STATUS_FROM_PROTO.get(d.status, DeviceStatus.OFFLINE),
         last_seen_at=d.last_seen_at or None,
         created_at=d.created_at,
         updated_at=d.updated_at,
@@ -128,7 +128,7 @@ async def update_device(
     body: UpdateDeviceRequest,
     stub: FromDishka[DevicesServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> UpdateDeviceResponse:
     response = await stub.UpdateDevice(
         devices_pb.UpdateDeviceRequest(
             user_id=current_user.user_id,
@@ -151,7 +151,7 @@ async def delete_device(
     stub: FromDishka[DevicesServiceStub],
     collector_stub: FromDishka[CollectorServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> DeleteResponse:
     response = await stub.DeleteDevice(
         devices_pb.DeleteDeviceRequest(
             user_id=current_user.user_id, place_id=str(place_id), device_id=str(device_id)
@@ -178,7 +178,7 @@ async def regenerate_token(
     device_id: UUID,
     stub: FromDishka[DevicesServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> RegenerateTokenResponse:
     response = await stub.RegenerateDeviceToken(
         devices_pb.RegenerateDeviceTokenRequest(
             user_id=current_user.user_id, place_id=str(place_id), device_id=str(device_id)

--- a/src/api/devices/schemas.py
+++ b/src/api/devices/schemas.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Self
+from typing import Any, Self
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -35,12 +35,12 @@ class DeviceSummaryResponse(BaseModel):
     last_seen_at: datetime | None
 
     @classmethod
-    def from_proto(cls, d) -> Self:
+    def from_proto(cls, d: Any) -> Self:
         return cls(
             device_id=d.device_id,
             place_id=d.place_id,
             name=d.name,
-            status=STATUS_FROM_PROTO.get(d.status, "offline"),
+            status=STATUS_FROM_PROTO.get(d.status, DeviceStatus.OFFLINE),
             last_seen_at=d.last_seen_at or None,
         )
 
@@ -55,13 +55,13 @@ class SensorResponse(BaseModel):
     precision: int
 
     @classmethod
-    def from_proto(cls, s) -> Self:
+    def from_proto(cls, s: Any) -> Self:
         return cls(
             sensor_id=s.sensor_id,
             device_id=s.device_id,
             key=s.key,
             name=s.name,
-            value_type=VALUE_TYPE_FROM_PROTO.get(s.value_type, "number"),
+            value_type=VALUE_TYPE_FROM_PROTO.get(s.value_type, ValueType.NUMBER),
             unit_label=s.unit_label,
             precision=s.precision,
         )
@@ -81,13 +81,13 @@ class ActuatorResponse(BaseModel):
     enum_options: list[str]
 
     @classmethod
-    def from_proto(cls, a) -> Self:
+    def from_proto(cls, a: Any) -> Self:
         return cls(
             actuator_id=a.actuator_id,
             device_id=a.device_id,
             key=a.key,
             name=a.name,
-            value_type=VALUE_TYPE_FROM_PROTO.get(a.value_type, "number"),
+            value_type=VALUE_TYPE_FROM_PROTO.get(a.value_type, ValueType.NUMBER),
             unit_label=a.unit_label,
             precision=a.precision,
             min_value=a.min_value,
@@ -171,13 +171,13 @@ class ThresholdResponse(BaseModel):
     severity: ThresholdSeverity
 
     @classmethod
-    def from_proto(cls, t) -> Self:
+    def from_proto(cls, t: Any) -> Self:
         return cls(
             threshold_id=t.threshold_id,
             sensor_id=t.sensor_id,
-            type=THRESHOLD_TYPE_FROM_PROTO.get(t.type, "min"),
+            type=THRESHOLD_TYPE_FROM_PROTO.get(t.type, ThresholdType.MIN),
             value=t.value,
-            severity=SEVERITY_FROM_PROTO.get(t.severity, "warning"),
+            severity=SEVERITY_FROM_PROTO.get(t.severity, ThresholdSeverity.WARNING),
         )
 
 

--- a/src/api/devices/sensors.py
+++ b/src/api/devices/sensors.py
@@ -43,7 +43,7 @@ async def create_sensor(
     body: CreateSensorRequest,
     stub: FromDishka[DevicesServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> CreateSensorResponse:
     response = await stub.CreateSensor(
         devices_pb.CreateSensorRequest(
             user_id=current_user.user_id,
@@ -51,7 +51,7 @@ async def create_sensor(
             device_id=str(device_id),
             key=body.key,
             name=body.name,
-            value_type=VALUE_TYPE_TO_PROTO[body.value_type],
+            value_type=VALUE_TYPE_TO_PROTO[body.value_type],  # type: ignore[arg-type]
             unit_label=body.unit_label,
             precision=body.precision,
         )
@@ -69,7 +69,7 @@ async def list_sensors(
     device_id: UUID,
     stub: FromDishka[DevicesServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> SensorListResponse:
     response = await stub.ListSensors(
         devices_pb.ListSensorsRequest(
             user_id=current_user.user_id, place_id=str(place_id), device_id=str(device_id)
@@ -90,7 +90,7 @@ async def update_sensor(
     body: UpdateSensorRequest,
     stub: FromDishka[DevicesServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> UpdateSensorResponse:
     response = await stub.UpdateSensor(
         devices_pb.UpdateSensorRequest(
             user_id=current_user.user_id,
@@ -116,7 +116,7 @@ async def delete_sensor(
     sensor_id: UUID,
     stub: FromDishka[DevicesServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> SuccessResponse:
     response = await stub.DeleteSensor(
         devices_pb.DeleteSensorRequest(
             user_id=current_user.user_id,

--- a/src/api/devices/thresholds.py
+++ b/src/api/devices/thresholds.py
@@ -42,16 +42,16 @@ async def set_threshold(
     body: SetThresholdRequest,
     stub: FromDishka[DevicesServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> SetThresholdResponse:
     response = await stub.SetThreshold(
         devices_pb.SetThresholdRequest(
             user_id=current_user.user_id,
             place_id=str(place_id),
             device_id=str(device_id),
             sensor_id=str(sensor_id),
-            type=THRESHOLD_TYPE_TO_PROTO[body.type],
+            type=THRESHOLD_TYPE_TO_PROTO[body.type],  # type: ignore[arg-type]
             value=body.value,
-            severity=SEVERITY_TO_PROTO[body.severity],
+            severity=SEVERITY_TO_PROTO[body.severity],  # type: ignore[arg-type]
         )
     )
     return SetThresholdResponse(threshold_id=response.threshold_id)
@@ -68,7 +68,7 @@ async def list_thresholds(
     sensor_id: UUID,
     stub: FromDishka[DevicesServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> ThresholdListResponse:
     response = await stub.ListThresholds(
         devices_pb.ListThresholdsRequest(
             user_id=current_user.user_id,
@@ -94,7 +94,7 @@ async def delete_threshold(
     threshold_id: UUID,
     stub: FromDishka[DevicesServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> SuccessResponse:
     response = await stub.DeleteThreshold(
         devices_pb.DeleteThresholdRequest(
             user_id=current_user.user_id,

--- a/src/api/mqtt/controllers.py
+++ b/src/api/mqtt/controllers.py
@@ -31,7 +31,7 @@ internal_router = APIRouter(
 async def generate_mqtt_credentials(
     stub: FromDishka[DevicesServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> MqttCredentialsResponse:
     response = await stub.GenerateMqttCredentials(
         devices_pb.GenerateMqttCredentialsRequest(user_id=current_user.user_id)
     )
@@ -46,7 +46,7 @@ async def generate_mqtt_credentials(
 async def mqtt_auth(
     body: MqttAuthRequest,
     stub: FromDishka[DevicesServiceStub],
-):
+) -> ORJSONResponse:
     response = await stub.AuthenticateDevice(
         devices_pb.AuthenticateDeviceRequest(username=body.username, password=body.password)
     )
@@ -59,7 +59,7 @@ async def mqtt_auth(
 async def mqtt_acl(
     body: MqttAclRequest,
     stub: FromDishka[DevicesServiceStub],
-):
+) -> ORJSONResponse:
     response = await stub.CheckDeviceAcl(
         devices_pb.CheckDeviceAclRequest(
             username=body.username, topic=body.topic, action=body.action

--- a/src/api/places/controllers.py
+++ b/src/api/places/controllers.py
@@ -14,7 +14,7 @@ from placebrain_contracts.collector_pb2_grpc import CollectorServiceStub
 from placebrain_contracts.devices_pb2_grpc import DevicesServiceStub
 from placebrain_contracts.places_pb2_grpc import PlacesServiceStub
 
-from src.core.enums import ROLE_FROM_PROTO, ROLE_TO_PROTO
+from src.core.enums import ROLE_FROM_PROTO, ROLE_TO_PROTO, PlaceRole
 from src.dependencies.auth import AuthenticatedUser
 from src.schemas.base import (
     AUTH_ERRORS,
@@ -54,7 +54,7 @@ async def create_place(
     stub: FromDishka[PlacesServiceStub],
     devices_stub: FromDishka[DevicesServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> CreatePlaceResponse:
     response = await stub.CreatePlace(
         places_pb.CreatePlaceRequest(
             user_id=current_user.user_id,
@@ -79,7 +79,7 @@ async def create_place(
 async def list_places(
     stub: FromDishka[PlacesServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> PlaceListResponse:
     response = await stub.ListPlaces(places_pb.ListPlacesRequest(user_id=current_user.user_id))
     return PlaceListResponse(places=[PlaceResponse.from_proto(p) for p in response.places])
 
@@ -93,7 +93,7 @@ async def get_place(
     place_id: UUID,
     stub: FromDishka[PlacesServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> PlaceResponse:
     response = await stub.GetPlace(
         places_pb.GetPlaceRequest(user_id=current_user.user_id, place_id=str(place_id))
     )
@@ -110,7 +110,7 @@ async def update_place(
     body: UpdatePlaceRequest,
     stub: FromDishka[PlacesServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> UpdatePlaceResponse:
     response = await stub.UpdatePlace(
         places_pb.UpdatePlaceRequest(
             user_id=current_user.user_id,
@@ -133,7 +133,7 @@ async def delete_place(
     devices_stub: FromDishka[DevicesServiceStub],
     collector_stub: FromDishka[CollectorServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> DeleteResponse:
     members_response = await stub.ListMembers(
         places_pb.ListMembersRequest(user_id=current_user.user_id, place_id=str(place_id))
     )
@@ -181,14 +181,14 @@ async def add_member(
     auth_stub: FromDishka[AuthServiceStub],
     devices_stub: FromDishka[DevicesServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> SuccessResponse:
     user_response = await auth_stub.GetUserByEmail(auth_pb.GetUserByEmailRequest(email=body.email))
     response = await stub.AddMember(
         places_pb.AddMemberRequest(
             user_id=current_user.user_id,
             place_id=str(place_id),
             target_user_id=user_response.user_id,
-            role=ROLE_TO_PROTO[body.role],
+            role=ROLE_TO_PROTO[body.role],  # type: ignore[arg-type]
         )
     )
     try:
@@ -211,7 +211,7 @@ async def remove_member(
     stub: FromDishka[PlacesServiceStub],
     devices_stub: FromDishka[DevicesServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> SuccessResponse:
     response = await stub.RemoveMember(
         places_pb.RemoveMemberRequest(
             user_id=current_user.user_id,
@@ -239,13 +239,13 @@ async def update_member_role(
     body: UpdateMemberRoleRequest,
     stub: FromDishka[PlacesServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> SuccessResponse:
     response = await stub.UpdateMemberRole(
         places_pb.UpdateMemberRoleRequest(
             user_id=current_user.user_id,
             place_id=str(place_id),
             target_user_id=str(user_id),
-            role=ROLE_TO_PROTO[body.role],
+            role=ROLE_TO_PROTO[body.role],  # type: ignore[arg-type]
         )
     )
     return SuccessResponse(success=response.success)
@@ -261,7 +261,7 @@ async def list_members(
     stub: FromDishka[PlacesServiceStub],
     auth_stub: FromDishka[AuthServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> MemberListResponse:
     response = await stub.ListMembers(
         places_pb.ListMembersRequest(user_id=current_user.user_id, place_id=str(place_id))
     )
@@ -276,7 +276,7 @@ async def list_members(
             MemberResponse(
                 user_id=m.user_id,
                 username=username_map.get(m.user_id, m.user_id),
-                role=ROLE_FROM_PROTO.get(m.role, "owner"),
+                role=ROLE_FROM_PROTO.get(m.role, PlaceRole.OWNER),
             )
             for m in response.members
         ]

--- a/src/api/places/schemas.py
+++ b/src/api/places/schemas.py
@@ -1,4 +1,4 @@
-from typing import Self
+from typing import Any, Self
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -22,12 +22,12 @@ class PlaceResponse(BaseModel):
     user_role: PlaceRole
 
     @classmethod
-    def from_proto(cls, p) -> Self:
+    def from_proto(cls, p: Any) -> Self:
         return cls(
             place_id=p.place_id,
             name=p.name,
             description=p.description,
-            user_role=ROLE_FROM_PROTO.get(p.user_role, "owner"),
+            user_role=ROLE_FROM_PROTO.get(p.user_role, PlaceRole.OWNER),
         )
 
 

--- a/src/api/telemetry/controllers.py
+++ b/src/api/telemetry/controllers.py
@@ -39,7 +39,7 @@ async def get_latest_readings(
     devices_stub: FromDishka[DevicesServiceStub],
     collector_stub: FromDishka[CollectorServiceStub],
     current_user: AuthenticatedUser,
-):
+) -> LatestReadingsResponse:
     await devices_stub.GetDevice(
         devices_pb.GetDeviceRequest(
             user_id=current_user.user_id, place_id=str(place_id), device_id=str(device_id)
@@ -96,7 +96,7 @@ async def get_readings_history(
         default=None,
         description="Comma-separated sensor keys to filter (e.g. 'temperature,humidity')",
     ),
-):
+) -> ReadingsHistoryResponse:
     await devices_stub.GetDevice(
         devices_pb.GetDeviceRequest(
             user_id=current_user.user_id,

--- a/src/dependencies/config.py
+++ b/src/dependencies/config.py
@@ -6,4 +6,4 @@ from src.core.config import Settings
 class ConfigProvider(Provider):
     @provide(scope=Scope.APP)
     def provide_settings(self) -> Settings:
-        return Settings()
+        return Settings()  # type: ignore[call-arg]

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 from dishka import make_async_container
@@ -20,7 +21,7 @@ container = make_async_container(
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI):
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     logging.basicConfig(
         level=settings.logging.level_value,
         format=settings.logging.format,

--- a/src/schemas/base.py
+++ b/src/schemas/base.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import Depends, Query
 from pydantic import BaseModel
@@ -40,7 +40,15 @@ PaginationParams = Annotated[_PaginationParams, Depends()]
 
 
 # Shared error response dicts for OpenAPI documentation
-AUTH_ERRORS = {401: {"description": "Not authenticated", "model": ErrorResponse}}
-FORBIDDEN_ERRORS = {403: {"description": "Permission denied", "model": ErrorResponse}}
-NOT_FOUND_ERRORS = {404: {"description": "Resource not found", "model": ErrorResponse}}
-CONFLICT_ERRORS = {409: {"description": "Resource already exists", "model": ErrorResponse}}
+AUTH_ERRORS: dict[int | str, dict[str, Any]] = {
+    401: {"description": "Not authenticated", "model": ErrorResponse}
+}
+FORBIDDEN_ERRORS: dict[int | str, dict[str, Any]] = {
+    403: {"description": "Permission denied", "model": ErrorResponse}
+}
+NOT_FOUND_ERRORS: dict[int | str, dict[str, Any]] = {
+    404: {"description": "Resource not found", "model": ErrorResponse}
+}
+CONFLICT_ERRORS: dict[int | str, dict[str, Any]] = {
+    409: {"description": "Resource already exists", "model": ErrorResponse}
+}

--- a/uv.lock
+++ b/uv.lock
@@ -73,6 +73,12 @@ dependencies = [
     { name = "python-multipart" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "dishka", specifier = ">=1.9.1" },
@@ -85,6 +91,12 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "pyjwt", specifier = ">=2.0.0" },
     { name = "python-multipart", specifier = ">=0.0.22" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.19.1" },
+    { name = "ruff", specifier = ">=0.14.10" },
 ]
 
 [[package]]
@@ -173,6 +185,78 @@ wheels = [
 ]
 
 [[package]]
+name = "librt"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/6b/3d5c13fb3e3c4f43206c8f9dfed13778c2ed4f000bacaa0b7ce3c402a265/librt-0.9.0.tar.gz", hash = "sha256:a0951822531e7aee6e0dfb556b30d5ee36bbe234faf60c20a16c01be3530869d", size = 184368, upload-time = "2026-04-09T16:06:26.173Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/c1/184e539543f06ea2912f4b92a5ffaede4f9b392689e3f00acbf8134bee92/librt-0.9.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:3f05d145df35dca5056a8bc3838e940efebd893a54b3e19b2dda39ceaa299bcb", size = 67830, upload-time = "2026-04-09T16:05:34.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ad/23399bdcb7afca819acacdef31b37ee59de261bd66b503a7995c03c4b0dc/librt-0.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1c587494461ebd42229d0f1739f3aa34237dd9980623ecf1be8d3bcba79f4499", size = 70280, upload-time = "2026-04-09T16:05:35.649Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/0b/4542dc5a2b8772dbf92cafb9194701230157e73c14b017b6961a23598b03/librt-0.9.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b0a2040f801406b93657a70b72fa12311063a319fee72ce98e1524da7200171f", size = 201925, upload-time = "2026-04-09T16:05:36.739Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d4/8ee7358b08fd0cfce051ef96695380f09b3c2c11b77c9bfbc367c921cce5/librt-0.9.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f38bc489037eca88d6ebefc9c4d41a4e07c8e8b4de5188a9e6d290273ad7ebb1", size = 212381, upload-time = "2026-04-09T16:05:38.043Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/94/a2025fe442abedf8b038038dab3dba942009ad42b38ea064a1a9e6094241/librt-0.9.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3fd278f5e6bf7c75ccd6d12344eb686cc020712683363b66f46ac79d37c799f", size = 227065, upload-time = "2026-04-09T16:05:39.394Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/e9/b9fcf6afa909f957cfbbf918802f9dada1bd5d3c1da43d722fd6a310dc3f/librt-0.9.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fcbdf2a9ca24e87bbebb47f1fe34e531ef06f104f98c9ccfc953a3f3344c567a", size = 221333, upload-time = "2026-04-09T16:05:40.999Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/7c/ba54cd6aa6a3c8cd12757a6870e0c79a64b1e6327f5248dcff98423f4d43/librt-0.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e306d956cfa027fe041585f02a1602c32bfa6bb8ebea4899d373383295a6c62f", size = 229051, upload-time = "2026-04-09T16:05:42.605Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4b/8cfdbad314c8677a0148bf0b70591d6d18587f9884d930276098a235461b/librt-0.9.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:465814ab157986acb9dfa5ccd7df944be5eefc0d08d31ec6e8d88bc71251d845", size = 222492, upload-time = "2026-04-09T16:05:43.842Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d1/2eda69563a1a88706808decdce035e4b32755dbfbb0d05e1a65db9547ed1/librt-0.9.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:703f4ae36d6240bfe24f542bac784c7e4194ec49c3ba5a994d02891649e2d85b", size = 223849, upload-time = "2026-04-09T16:05:45.054Z" },
+    { url = "https://files.pythonhosted.org/packages/04/44/b2ed37df6be5b3d42cfe36318e0598e80843d5c6308dd63d0bf4e0ce5028/librt-0.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3be322a15ee5e70b93b7a59cfd074614f22cc8c9ff18bd27f474e79137ea8d3b", size = 245001, upload-time = "2026-04-09T16:05:46.34Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e7/617e412426df89169dd2a9ed0cc8752d5763336252c65dbf945199915119/librt-0.9.0-cp314-cp314-win32.whl", hash = "sha256:b8da9f8035bb417770b1e1610526d87ad4fc58a2804dc4d79c53f6d2cf5a6eb9", size = 51799, upload-time = "2026-04-09T16:05:47.738Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ed/c22ca4db0ca3cbc285e4d9206108746beda561a9792289c3c31281d7e9df/librt-0.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:b8bd70d5d816566a580d193326912f4a76ec2d28a97dc4cd4cc831c0af8e330e", size = 59165, upload-time = "2026-04-09T16:05:49.198Z" },
+    { url = "https://files.pythonhosted.org/packages/24/56/875398fafa4cbc8f15b89366fc3287304ddd3314d861f182a4b87595ace0/librt-0.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:fc5758e2b7a56532dc33e3c544d78cbaa9ecf0a0f2a2da2df882c1d6b99a317f", size = 49292, upload-time = "2026-04-09T16:05:50.362Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/61/bc448ecbf9b2d69c5cff88fe41496b19ab2a1cbda0065e47d4d0d51c0867/librt-0.9.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:f24b90b0e0c8cc9491fb1693ae91fe17cb7963153a1946395acdbdd5818429a4", size = 70175, upload-time = "2026-04-09T16:05:51.564Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f2/c47bb71069a73e2f04e70acbd196c1e5cc411578ac99039a224b98920fd4/librt-0.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3fe56e80badb66fdcde06bef81bbaa5bfcf6fbd7aefb86222d9e369c38c6b228", size = 72951, upload-time = "2026-04-09T16:05:52.699Z" },
+    { url = "https://files.pythonhosted.org/packages/29/19/0549df59060631732df758e8886d92088da5fdbedb35b80e4643664e8412/librt-0.9.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:527b5b820b47a09e09829051452bb0d1dd2122261254e2a6f674d12f1d793d54", size = 225864, upload-time = "2026-04-09T16:05:53.895Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f8/3b144396d302ac08e50f89e64452c38db84bc7b23f6c60479c5d3abd303c/librt-0.9.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d429bdd4ac0ab17c8e4a8af0ed2a7440b16eba474909ab357131018fe8c7e71", size = 241155, upload-time = "2026-04-09T16:05:55.191Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/ce/ee67ec14581de4043e61d05786d2aed6c9b5338816b7859bcf07455c6a9f/librt-0.9.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7202bdcac47d3a708271c4304a474a8605a4a9a4a709e954bf2d3241140aa938", size = 252235, upload-time = "2026-04-09T16:05:56.549Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fa/0ead15daa2b293a54101550b08d4bafe387b7d4a9fc6d2b985602bae69b6/librt-0.9.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0d620e74897f8c2613b3c4e2e9c1e422eb46d2ddd07df540784d44117836af3", size = 244963, upload-time = "2026-04-09T16:05:57.858Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/9fbf9a9aa704ba87689e40017e720aced8d9a4d2b46b82451d8142f91ec9/librt-0.9.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d69fc39e627908f4c03297d5a88d9284b73f4d90b424461e32e8c2485e21c283", size = 257364, upload-time = "2026-04-09T16:05:59.686Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8d/9d60869f1b6716c762e45f66ed945b1e5dd649f7377684c3b176ae424648/librt-0.9.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:c2640e23d2b7c98796f123ffd95cf2022c7777aa8a4a3b98b36c570d37e85eee", size = 247661, upload-time = "2026-04-09T16:06:00.938Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ff/a5c365093962310bfdb4f6af256f191085078ffb529b3f0cbebb5b33ebe2/librt-0.9.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:451daa98463b7695b0a30aa56bf637831ea559e7b8101ac2ef6382e8eb15e29c", size = 248238, upload-time = "2026-04-09T16:06:02.537Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/3c/2d34365177f412c9e19c0a29f969d70f5343f27634b76b765a54d8b27705/librt-0.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:928bd06eca2c2bbf4349e5b817f837509b0604342e65a502de1d50a7570afd15", size = 269457, upload-time = "2026-04-09T16:06:03.833Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/cd/de45b239ea3bdf626f982a00c14bfcf2e12d261c510ba7db62c5969a27cd/librt-0.9.0-cp314-cp314t-win32.whl", hash = "sha256:a9c63e04d003bc0fb6a03b348018b9a3002f98268200e22cc80f146beac5dc40", size = 52453, upload-time = "2026-04-09T16:06:05.229Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f9/bfb32ae428aa75c0c533915622176f0a17d6da7b72b5a3c6363685914f70/librt-0.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f162af66a2ed3f7d1d161a82ca584efd15acd9c1cff190a373458c32f7d42118", size = 60044, upload-time = "2026-04-09T16:06:06.398Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/47/7d70414bcdbb3bc1f458a8d10558f00bbfdb24e5a11740fc8197e12c3255/librt-0.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:a4b25c6c25cac5d0d9d6d6da855195b254e0021e513e0249f0e3b444dc6e0e61", size = 50009, upload-time = "2026-04-09T16:06:07.995Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "1.20.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/3d/5b373635b3146264eb7a68d09e5ca11c305bbb058dfffbb47c47daf4f632/mypy-1.20.1.tar.gz", hash = "sha256:6fc3f4ecd52de81648fed1945498bf42fa2993ddfad67c9056df36ae5757f804", size = 3815892, upload-time = "2026-04-13T02:46:51.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/cd/db831e84c81d57d4886d99feee14e372f64bbec6a9cb1a88a19e243f2ef5/mypy-1.20.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:12927b9c0ed794daedcf1dab055b6c613d9d5659ac511e8d936d96f19c087d12", size = 14483064, upload-time = "2026-04-13T02:45:26.901Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/82/74e62e7097fa67da328ac8ece8de09133448c04d20ddeaeba251a3000f01/mypy-1.20.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:752507dd481e958b2c08fc966d3806c962af5a9433b5bf8f3bdd7175c20e34fe", size = 13335694, upload-time = "2026-04-13T02:46:12.514Z" },
+    { url = "https://files.pythonhosted.org/packages/74/c4/97e9a0abe4f3cdbbf4d079cb87a03b786efeccf5bf2b89fe4f96939ab2e6/mypy-1.20.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c614655b5a065e56274c6cbbe405f7cf7e96c0654db7ba39bc680238837f7b08", size = 13726365, upload-time = "2026-04-13T02:45:17.422Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/aa/a19d884a8d28fcd3c065776323029f204dbc774e70ec9c85eba228b680de/mypy-1.20.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2c3f6221a76f34d5100c6d35b3ef6b947054123c3f8d6938a4ba00b1308aa572", size = 14693472, upload-time = "2026-04-13T02:46:41.253Z" },
+    { url = "https://files.pythonhosted.org/packages/84/44/cc9324bd21cf786592b44bf3b5d224b3923c1230ec9898d508d00241d465/mypy-1.20.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4bdfc06303ac06500af71ea0cdbe995c502b3c9ba32f3f8313523c137a25d1b6", size = 14919266, upload-time = "2026-04-13T02:46:28.37Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/dc/779abb25a8c63e8f44bf5a336217fa92790fa17e0c40e0c725d10cb01bbd/mypy-1.20.1-cp314-cp314-win_amd64.whl", hash = "sha256:0131edd7eba289973d1ba1003d1a37c426b85cdef76650cd02da6420898a5eb3", size = 11049713, upload-time = "2026-04-13T02:45:57.673Z" },
+    { url = "https://files.pythonhosted.org/packages/28/08/4172be2ad7de9119b5a92ca36abbf641afdc5cb1ef4ae0c3a8182f29674f/mypy-1.20.1-cp314-cp314-win_arm64.whl", hash = "sha256:33f02904feb2c07e1fdf7909026206396c9deeb9e6f34d466b4cfedb0aadbbe4", size = 9999819, upload-time = "2026-04-13T02:46:35.039Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/af/af9e46b0c8eabbce9fc04a477564170f47a1c22b308822282a59b7ff315f/mypy-1.20.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:168472149dd8cc505c98cefd21ad77e4257ed6022cd5ed2fe2999bed56977a5a", size = 15547508, upload-time = "2026-04-13T02:46:25.588Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/cd/39c9e4ad6ba33e069e5837d772a9e6c304b4a5452a14a975d52b36444650/mypy-1.20.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:eb674600309a8f22790cca883a97c90299f948183ebb210fbef6bcee07cb1986", size = 14399557, upload-time = "2026-04-13T02:46:10.021Z" },
+    { url = "https://files.pythonhosted.org/packages/83/c1/3fd71bdc118ffc502bf57559c909927bb7e011f327f7bb8e0488e98a5870/mypy-1.20.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef2b2e4cc464ba9795459f2586923abd58a0055487cbe558cb538ea6e6bc142a", size = 15045789, upload-time = "2026-04-13T02:45:10.81Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/73/6f07ff8b57a7d7b3e6e5bf34685d17632382395c8bb53364ec331661f83e/mypy-1.20.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dee461d396dd46b3f0ed5a098dbc9b8860c81c46ad44fa071afcfbc149f167c9", size = 15850795, upload-time = "2026-04-13T02:45:03.349Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e2/f7dffec1c7767078f9e9adf0c786d1fe0ff30964a77eb213c09b8b58cb76/mypy-1.20.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e364926308b3e66f1361f81a566fc1b2f8cd47fc8525e8136d4058a65a4b4f02", size = 16088539, upload-time = "2026-04-13T02:46:17.841Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/76/e0dee71035316e75a69d73aec2f03c39c21c967b97e277fd0ef8fd6aec66/mypy-1.20.1-cp314-cp314t-win_amd64.whl", hash = "sha256:a0c17fbd746d38c70cbc42647cfd884f845a9708a4b160a8b4f7e70d41f4d7fa", size = 12575567, upload-time = "2026-04-13T02:45:34.795Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a8/7ed43c9d9c3d1468f86605e323a5d97e411a448790a00f07e779f3211a46/mypy-1.20.1-cp314-cp314t-win_arm64.whl", hash = "sha256:db2cb89654626a912efda69c0d5c1d22d948265e2069010d3dde3abf751c7d08", size = 10378823, upload-time = "2026-04-13T02:45:13.35Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/28/926bd972388e65a39ee98e188ccf67e81beb3aacfd5d6b310051772d974b/mypy-1.20.1-py3-none-any.whl", hash = "sha256:1aae28507f253fe82d883790d1c0a0d35798a810117c88184097fe8881052f06", size = 2636553, upload-time = "2026-04-13T02:46:30.45Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
 name = "orjson"
 version = "3.11.7"
 source = { registry = "https://pypi.org/simple" }
@@ -193,6 +277,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/d3/f19b47ce16820cc2c480f7f1723e17f6d411b3a295c60c8ad3aa9ff1c96a/orjson-3.11.7-cp314-cp314-win32.whl", hash = "sha256:89e13dd3f89f1c38a9c9eba5fbf7cdc2d1feca82f5f290864b4b7a6aac704576", size = 127997, upload-time = "2026-02-02T15:38:45.06Z" },
     { url = "https://files.pythonhosted.org/packages/12/df/172771902943af54bf661a8d102bdf2e7f932127968080632bda6054b62c/orjson-3.11.7-cp314-cp314-win_amd64.whl", hash = "sha256:845c3e0d8ded9c9271cd79596b9b552448b885b97110f628fb687aee2eed11c1", size = 124985, upload-time = "2026-02-02T15:38:46.388Z" },
     { url = "https://files.pythonhosted.org/packages/6f/1c/f2a8d8a1b17514660a614ce5f7aac74b934e69f5abc2700cc7ced882a009/orjson-3.11.7-cp314-cp314-win_arm64.whl", hash = "sha256:4a2e9c5be347b937a2e0203866f12bba36082e89b402ddb9e927d5822e43088d", size = 126038, upload-time = "2026-02-02T15:38:47.703Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
 ]
 
 [[package]]
@@ -325,6 +418,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/d9/aa3f7d59a10ef6b14fe3431706f854dbf03c5976be614a9796d36326810c/ruff-0.15.10.tar.gz", hash = "sha256:d1f86e67ebfdef88e00faefa1552b5e510e1d35f3be7d423dc7e84e63788c94e", size = 4631728, upload-time = "2026-04-09T14:06:09.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/00/a1c2fdc9939b2c03691edbda290afcd297f1f389196172826b03d6b6a595/ruff-0.15.10-py3-none-linux_armv6l.whl", hash = "sha256:0744e31482f8f7d0d10a11fcbf897af272fefdfcb10f5af907b18c2813ff4d5f", size = 10563362, upload-time = "2026-04-09T14:06:21.189Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/15/006990029aea0bebe9d33c73c3e28c80c391ebdba408d1b08496f00d422d/ruff-0.15.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b1e7c16ea0ff5a53b7c2df52d947e685973049be1cdfe2b59a9c43601897b22e", size = 10951122, upload-time = "2026-04-09T14:06:02.236Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c0/4ac978fe874d0618c7da647862afe697b281c2806f13ce904ad652fa87e4/ruff-0.15.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:93cc06a19e5155b4441dd72808fdf84290d84ad8a39ca3b0f994363ade4cebb1", size = 10314005, upload-time = "2026-04-09T14:06:00.026Z" },
+    { url = "https://files.pythonhosted.org/packages/da/73/c209138a5c98c0d321266372fc4e33ad43d506d7e5dd817dd89b60a8548f/ruff-0.15.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83e1dd04312997c99ea6965df66a14fb4f03ba978564574ffc68b0d61fd3989e", size = 10643450, upload-time = "2026-04-09T14:05:42.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/76/0deec355d8ec10709653635b1f90856735302cb8e149acfdf6f82a5feb70/ruff-0.15.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8154d43684e4333360fedd11aaa40b1b08a4e37d8ffa9d95fee6fa5b37b6fab1", size = 10379597, upload-time = "2026-04-09T14:05:49.984Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/be/86bba8fc8798c081e28a4b3bb6d143ccad3fd5f6f024f02002b8f08a9fa3/ruff-0.15.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ab88715f3a6deb6bde6c227f3a123410bec7b855c3ae331b4c006189e895cef", size = 11146645, upload-time = "2026-04-09T14:06:12.246Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/89/140025e65911b281c57be1d385ba1d932c2366ca88ae6663685aed8d4881/ruff-0.15.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a768ff5969b4f44c349d48edf4ab4f91eddb27fd9d77799598e130fb628aa158", size = 12030289, upload-time = "2026-04-09T14:06:04.776Z" },
+    { url = "https://files.pythonhosted.org/packages/88/de/ddacca9545a5e01332567db01d44bd8cf725f2db3b3d61a80550b48308ea/ruff-0.15.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ee3ef42dab7078bda5ff6a1bcba8539e9857deb447132ad5566a038674540d0", size = 11496266, upload-time = "2026-04-09T14:05:55.485Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/bb/7ddb00a83760ff4a83c4e2fc231fd63937cc7317c10c82f583302e0f6586/ruff-0.15.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51cb8cc943e891ba99989dd92d61e29b1d231e14811db9be6440ecf25d5c1609", size = 11256418, upload-time = "2026-04-09T14:05:57.69Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8d/55de0d35aacf6cd50b6ee91ee0f291672080021896543776f4170fc5c454/ruff-0.15.10-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e59c9bdc056a320fb9ea1700a8d591718b8faf78af065484e801258d3a76bc3f", size = 11288416, upload-time = "2026-04-09T14:05:44.695Z" },
+    { url = "https://files.pythonhosted.org/packages/68/cf/9438b1a27426ec46a80e0a718093c7f958ef72f43eb3111862949ead3cc1/ruff-0.15.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:136c00ca2f47b0018b073f28cb5c1506642a830ea941a60354b0e8bc8076b151", size = 10621053, upload-time = "2026-04-09T14:05:52.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/50/e29be6e2c135e9cd4cb15fbade49d6a2717e009dff3766dd080fcb82e251/ruff-0.15.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8b80a2f3c9c8a950d6237f2ca12b206bccff626139be9fa005f14feb881a1ae8", size = 10378302, upload-time = "2026-04-09T14:06:14.361Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2f/e0b36a6f99c51bb89f3a30239bc7bf97e87a37ae80aa2d6542d6e5150364/ruff-0.15.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:e3e53c588164dc025b671c9df2462429d60357ea91af7e92e9d56c565a9f1b07", size = 10850074, upload-time = "2026-04-09T14:06:16.581Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/874da392558ce087a0f9b709dc6ec0d60cbc694c1c772dab8d5f31efe8cb/ruff-0.15.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b0c52744cf9f143a393e284125d2576140b68264a93c6716464e129a3e9adb48", size = 11358051, upload-time = "2026-04-09T14:06:18.948Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964, upload-time = "2026-04-09T14:06:07.14Z" },
+    { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044, upload-time = "2026-04-09T14:05:39.473Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607, upload-time = "2026-04-09T14:05:47.593Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add dev dependencies (ruff, mypy) to pyproject.toml
- Add return type annotations to all controller functions
- Fix `from_proto` method type annotations in schemas
- Type-annotate OpenAPI error response dicts in `base.py`
- Add mypy override for google.protobuf
- Fix proto enum type ignores for gRPC request construction
- Fix pydantic-settings `Settings()` type ignore