### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Summary
+
+<!-- One or two sentences: what this PR does and why. -->
+
+## Changes
+
+<!-- Bullet list of notable changes. -->
+
+-
+
+## Verification
+
+<!-- Check what you actually ran/clicked. Uncheck and note what you skipped, with a reason. -->
+
+- [ ] `uv run ruff check` — clean
+- [ ] `uv run ruff format --check` — clean
+- [ ] `uv run mypy` — clean
+- [ ] `make dev` up from project root, all services healthy (if runtime affected)
+- [ ] Manually exercised the primary flow this change touches (via frontend or `curl`)
+- [ ] Checked `make logs` (gateway + backing gRPC services) for new errors
+
+## Linked issues
+
+Closes #


### PR DESCRIPTION
## Summary

Adds `.github/PULL_REQUEST_TEMPLATE.md` so every PR in this repo starts with the same Summary / Changes / Verification / Linked issues skeleton. Verification checklist is tailored to this repo's stack.

## Changes

- Add `.github/PULL_REQUEST_TEMPLATE.md`.

## Verification

- [x] Template renders as expected when opening this PR (you're looking at it)